### PR TITLE
feat: add GPX track replay functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Designed for testing GPS-dependent applications, embedded systems development, o
 - **Speed & Course Simulation**: Configurable static speed and course values in NMEA output
 - **Realistic Signal Simulation**: Dynamic satellite positions and signal strength
 - **GPX Track Generation**: Export GPS tracks to GPX files for analysis and visualization
+- **GPX Track Replay**: Replay existing GPX files with configurable speed multipliers
 - **Duration Control**: Automatic simulation termination after specified time periods
 
 ## Installation
@@ -78,6 +79,8 @@ gps-simulator [options]
 | `-quiet`           | bool     | false     | Suppress informational messages (only output NMEA data)  |
 | `-gpx`             | bool     | false     | Generate GPX track file with timestamp-based filename    |
 | `-duration`        | duration | 0         | How long to run the simulation (e.g., 30s, 5m, 1h)      |
+| `-replay`          | string   | ""        | GPX file to replay instead of simulating (e.g., track.gpx) |
+| `-replay-speed`    | float    | 1.0       | Replay speed multiplier (1.0=real-time, 2.0=2x speed, 0.5=half speed) |
 
 **Note**: When using `-gpx`, the `-duration` flag is required.
 
@@ -285,6 +288,38 @@ Automated testing scenario
 gps-simulator -gpx -duration 10m -quiet -lat 51.5074 -lon -0.1278 -speed 5.0
 ```
 
+#### GPX Replay Examples
+
+Replay a GPX track at real-time speed
+
+```bash
+gps-simulator -replay my_track.gpx
+```
+
+Replay at 2x speed for faster testing
+
+```bash
+gps-simulator -replay my_track.gpx -replay-speed 2.0
+```
+
+Slow motion replay at half speed
+
+```bash
+gps-simulator -replay my_track.gpx -replay-speed 0.5
+```
+
+Replay with custom output settings
+
+```bash
+gps-simulator -replay journey.gpx -rate 500ms -serial /dev/ttyUSB0 -baud 4800
+```
+
+Quiet replay for piping to applications
+
+```bash
+gps-simulator -replay track.gpx -quiet -replay-speed 5.0 | nmea_parser
+```
+
 #### Live GPS Stream Viewing
 
 Quick Demo (Everything Automatic)
@@ -385,6 +420,15 @@ The simulator outputs the following NMEA0183 sentence types:
 - **Post-GPS Lock**: Only records track points after GPS lock is achieved for accurate data
 - **Duration Required**: The `-duration` flag must be specified when using `-gpx` to ensure controlled file size
 
+### GPX Track Replay
+
+- **Standard GPX 1.1 Support**: Reads industry-standard GPX files from any GPS application or device
+- **Automatic Speed/Course Calculation**: Calculates realistic speed and course values from track point timestamps and positions
+- **Configurable Replay Speed**: Speed multipliers from 0.1x (slow motion) to 10x+ (fast forward) for testing scenarios
+- **Seamless NMEA Integration**: Replayed positions generate the same NMEA sentences as simulated data
+- **Loop Functionality**: Automatically restarts from the beginning when reaching the end of the track
+- **Time-Based Progression**: Respects original GPX timestamps for accurate replay timing
+
 ## Development
 
 ### Helper Scripts
@@ -441,8 +485,12 @@ The simulator outputs the following NMEA0183 sentence types:
   - GLONASS, Galileo, BeiDou satellites
   - Constellation-specific NMEA sentences (GLGGA, GNGGA, etc.)
   - Different satellite ID ranges
+- [x] **GPX Track Replay** - Replay existing GPX files with NMEA output
+  - Standard GPX 1.1 file format support
+  - Configurable replay speed multipliers (0.1x to 10x+)
+  - Automatic speed and course calculation from track data
+  - Seamless integration with all existing NMEA output features
 - [ ] **Predefined Routes** - Follow realistic movement patterns
-  - GPX file import for route following
   - City/highway driving patterns
   - Airport runway procedures
   - Maritime shipping lanes

--- a/simulator.go
+++ b/simulator.go
@@ -23,6 +23,10 @@ type GPSSimulator struct {
 	satellites     []Satellite
 	nmeaWriter     io.Writer
 	gpxWriter      *GPXWriter
+	// Replay mode fields
+	replayPoints    []TrackPoint
+	replayIndex     int
+	replayStartTime time.Time
 }
 
 type Satellite struct {
@@ -35,17 +39,35 @@ type Satellite struct {
 func NewGPSSimulator(config Config, nmeaWriter io.Writer) (*GPSSimulator, error) {
 	now := time.Now()
 	sim := &GPSSimulator{
-		config:         config,
-		currentLat:     config.Latitude,
-		currentLon:     config.Longitude,
-		currentAlt:     config.Altitude,
-		currentSpeed:   config.Speed,
-		currentCourse:  config.Course,
-		isLocked:       false,
-		startTime:      now,
-		lockTime:       now.Add(config.TimeToLock),
-		lastUpdateTime: now,
-		nmeaWriter:     nmeaWriter,
+		config:          config,
+		currentLat:      config.Latitude,
+		currentLon:      config.Longitude,
+		currentAlt:      config.Altitude,
+		currentSpeed:    config.Speed,
+		currentCourse:   config.Course,
+		isLocked:        false,
+		startTime:       now,
+		lockTime:        now.Add(config.TimeToLock),
+		lastUpdateTime:  now,
+		nmeaWriter:      nmeaWriter,
+		replayIndex:     0,
+		replayStartTime: now,
+	}
+
+	// Load GPX file for replay mode
+	if config.ReplayFile != "" {
+		points, err := ReadGPXFile(config.ReplayFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load replay file: %v", err)
+		}
+		sim.replayPoints = points
+
+		// Set initial position from first track point
+		if len(points) > 0 {
+			sim.currentLat = points[0].Lat
+			sim.currentLon = points[0].Lon
+			sim.currentAlt = points[0].Elevation
+		}
 	}
 
 	// Initialize GPX writer if GPX is enabled
@@ -154,9 +176,13 @@ func (s *GPSSimulator) update() {
 
 	// Update position if locked
 	if s.isLocked {
-		s.updateSpeedAndCourse()
-		s.updatePosition()
-		s.updateAltitude()
+		if s.config.ReplayFile != "" {
+			s.updateReplayPosition()
+		} else {
+			s.updateSpeedAndCourse()
+			s.updatePosition()
+			s.updateAltitude()
+		}
 	}
 
 	// Update satellites
@@ -336,6 +362,21 @@ func (s *GPSSimulator) distanceFromCenter(lat, lon float64) float64 {
 	return R * c
 }
 
+// hasSequentialTimestamps checks if the replay points have sequential timestamps
+func (s *GPSSimulator) hasSequentialTimestamps() bool {
+	if len(s.replayPoints) < 2 {
+		return false
+	}
+
+	// Check if timestamps are generally increasing
+	for i := 0; i < len(s.replayPoints)-1; i++ {
+		if s.replayPoints[i+1].Time.Before(s.replayPoints[i].Time) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *GPSSimulator) updateSatellites() {
 	// Simulate satellite movement and signal changes
 	for i := range s.satellites {
@@ -398,4 +439,116 @@ func (s *GPSSimulator) outputNMEA() {
 	}
 
 	// No extra blank lines - NMEA sentences should be continuous
+}
+
+// updateReplayPosition updates position based on GPX replay data
+func (s *GPSSimulator) updateReplayPosition() {
+	if len(s.replayPoints) == 0 {
+		return
+	}
+
+	now := time.Now()
+	elapsedTime := now.Sub(s.replayStartTime)
+
+	// Apply replay speed multiplier
+	adjustedTime := time.Duration(float64(elapsedTime) * s.config.ReplaySpeed)
+
+	// Check if timestamps are sequential for time-based progression
+	useTimestamps := s.hasSequentialTimestamps()
+
+	if useTimestamps {
+		// Time-based progression using GPX timestamps
+		targetTime := s.replayPoints[0].Time.Add(adjustedTime)
+
+		// Find the track point that should be active at this time
+		for i := s.replayIndex; i < len(s.replayPoints)-1; i++ {
+			if targetTime.Before(s.replayPoints[i+1].Time) {
+				s.replayIndex = i
+				break
+			}
+			if i == len(s.replayPoints)-2 {
+				s.replayIndex = i + 1
+				break
+			}
+		}
+	} else {
+		// Index-based progression when timestamps are not sequential
+		// Progress through points at a steady rate (1 point per second at 1x speed)
+		pointInterval := time.Second / time.Duration(s.config.ReplaySpeed)
+		pointsSinceStart := int(elapsedTime / pointInterval)
+		s.replayIndex = pointsSinceStart % len(s.replayPoints)
+	}
+
+	// If we've reached the end, loop back to start
+	if s.replayIndex >= len(s.replayPoints) {
+		s.replayIndex = 0
+		s.replayStartTime = now
+		return
+	}
+
+	// Update current position from track point
+	currentPoint := s.replayPoints[s.replayIndex]
+	s.currentLat = currentPoint.Lat
+	s.currentLon = currentPoint.Lon
+	s.currentAlt = currentPoint.Elevation
+
+	// Calculate speed and course from next point if available
+	if s.replayIndex < len(s.replayPoints)-1 {
+		nextPoint := s.replayPoints[s.replayIndex+1]
+
+		// Calculate distance and time between points
+		distance := s.calculateDistance(s.currentLat, s.currentLon, nextPoint.Lat, nextPoint.Lon)
+
+		var timeDiff float64
+		if useTimestamps {
+			timeDiff = nextPoint.Time.Sub(currentPoint.Time).Seconds()
+		} else {
+			// Use a fixed time interval for non-sequential timestamps
+			timeDiff = 1.0 // 1 second between points
+		}
+
+		if timeDiff > 0 {
+			// Convert m/s to knots (1 m/s = 1.94384 knots)
+			s.currentSpeed = (distance / timeDiff) * 1.94384
+
+			// Calculate course (bearing) to next point
+			s.currentCourse = s.calculateBearing(s.currentLat, s.currentLon, nextPoint.Lat, nextPoint.Lon)
+		}
+	}
+}
+
+// calculateBearing calculates the bearing from point 1 to point 2
+func (s *GPSSimulator) calculateBearing(lat1, lon1, lat2, lon2 float64) float64 {
+	lat1Rad := lat1 * math.Pi / 180
+	lat2Rad := lat2 * math.Pi / 180
+	deltaLonRad := (lon2 - lon1) * math.Pi / 180
+
+	y := math.Sin(deltaLonRad) * math.Cos(lat2Rad)
+	x := math.Cos(lat1Rad)*math.Sin(lat2Rad) - math.Sin(lat1Rad)*math.Cos(lat2Rad)*math.Cos(deltaLonRad)
+
+	bearing := math.Atan2(y, x) * 180 / math.Pi
+
+	// Normalize to 0-359 degrees
+	if bearing < 0 {
+		bearing += 360
+	}
+
+	return bearing
+}
+
+// calculateDistance calculates the distance between two points using the Haversine formula
+func (s *GPSSimulator) calculateDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	const R = 6371000 // Earth's radius in meters
+
+	lat1Rad := lat1 * math.Pi / 180
+	lat2Rad := lat2 * math.Pi / 180
+	deltaLat := (lat2 - lat1) * math.Pi / 180
+	deltaLon := (lon2 - lon1) * math.Pi / 180
+
+	a := math.Sin(deltaLat/2)*math.Sin(deltaLat/2) +
+		math.Cos(lat1Rad)*math.Cos(lat2Rad)*
+			math.Sin(deltaLon/2)*math.Sin(deltaLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	return R * c
 }


### PR DESCRIPTION
- Introduced support for replaying GPX tracks with configurable speed multipliers in the GPS simulator.
- Updated the Config struct to include `ReplayFile` and `ReplaySpeed` fields.
- Enhanced GPSSimulator to load GPX files for replay and update position based on replay data.
- Implemented logic for sequential timestamp handling and position updates during replay.
- Updated README to document new replay features and usage examples.