### PR TITLE
feat: add replay loop functionality to GPS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ gps-simulator [options]
 | `-duration`        | duration | 0         | How long to run the simulation (e.g., 30s, 5m, 1h)      |
 | `-replay`          | string   | ""        | GPX file to replay instead of simulating (e.g., track.gpx) |
 | `-replay-speed`    | float    | 1.0       | Replay speed multiplier (1.0=real-time, 2.0=2x speed, 0.5=half speed) |
+| `-replay-loop`     | bool     | false     | Loop the GPX replay continuously (default: stop after one pass) |
 
 **Note**: When using `-gpx`, the `-duration` flag is required.
 
@@ -290,10 +291,16 @@ gps-simulator -gpx -duration 10m -quiet -lat 51.5074 -lon -0.1278 -speed 5.0
 
 #### GPX Replay Examples
 
-Replay a GPX track at real-time speed
+Replay a GPX track once at real-time speed (default behavior)
 
 ```bash
 gps-simulator -replay my_track.gpx
+```
+
+Replay continuously in a loop
+
+```bash
+gps-simulator -replay my_track.gpx -replay-loop
 ```
 
 Replay at 2x speed for faster testing
@@ -306,6 +313,12 @@ Slow motion replay at half speed
 
 ```bash
 gps-simulator -replay my_track.gpx -replay-speed 0.5
+```
+
+Continuous loop at high speed for stress testing
+
+```bash
+gps-simulator -replay track.gpx -replay-loop -replay-speed 10.0
 ```
 
 Replay with custom output settings
@@ -426,8 +439,10 @@ The simulator outputs the following NMEA0183 sentence types:
 - **Automatic Speed/Course Calculation**: Calculates realistic speed and course values from track point timestamps and positions
 - **Configurable Replay Speed**: Speed multipliers from 0.1x (slow motion) to 10x+ (fast forward) for testing scenarios
 - **Seamless NMEA Integration**: Replayed positions generate the same NMEA sentences as simulated data
-- **Loop Functionality**: Automatically restarts from the beginning when reaching the end of the track
+- **Single Pass Default**: By default, stops after completing one pass through the track points
+- **Optional Loop Functionality**: Use `-replay-loop` flag to continuously restart from the beginning when reaching the end
 - **Time-Based Progression**: Respects original GPX timestamps for accurate replay timing
+- **Automatic Completion**: Shows "GPX replay completed" message when finishing a single pass
 
 ## Development
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ type Config struct {
 	Duration       time.Duration // How long to run the simulation (0 = run indefinitely)
 	ReplayFile     string        // GPX file to replay (empty = normal simulation mode)
 	ReplaySpeed    float64       // Replay speed multiplier (1.0 = real-time, 2.0 = 2x speed, etc.)
+	ReplayLoop     bool          // Whether to loop the replay (false = stop after one pass, true = loop continuously)
 }
 
 func main() {
@@ -64,6 +65,7 @@ func main() {
 	flag.DurationVar(&config.Duration, "duration", 0, "How long to run the simulation (e.g., 30s, 5m, 1h). Default is indefinite")
 	flag.StringVar(&config.ReplayFile, "replay", "", "GPX file to replay instead of simulating (e.g., track.gpx)")
 	flag.Float64Var(&config.ReplaySpeed, "replay-speed", 1.0, "Replay speed multiplier (1.0=real-time, 2.0=2x speed, 0.5=half speed)")
+	flag.BoolVar(&config.ReplayLoop, "replay-loop", false, "Loop the GPX replay continuously (default: stop after one pass)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n", os.Args[0])

--- a/simulator_test.go
+++ b/simulator_test.go
@@ -2256,6 +2256,7 @@ func TestUpdateReplayPosition(t *testing.T) {
 	config := createTestConfig()
 	config.ReplayFile = tempFile
 	config.ReplaySpeed = 2.0 // 2x speed
+	config.ReplayLoop = true // Enable looping for this test
 
 	buffer := &bytes.Buffer{}
 	sim, err := NewGPSSimulator(config, buffer)


### PR DESCRIPTION
- Introduced a new `ReplayLoop` boolean field in the `Config` struct to enable continuous looping of GPX replays.
- Updated the `GPSSimulator` to handle replay completion and looping behavior based on the new configuration.
- Enhanced the README to document the new `-replay-loop` flag and provide usage examples for continuous replay.
- Added notes on the default behavior of single pass and optional looping in the output section.

Signed-off-by: Alex Bucknall <alex.bucknall@gmail.com>