### PR TITLE
refactor: make package importable

### DIFF
--- a/cmd/gps-simulator/main.go
+++ b/cmd/gps-simulator/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.bug.st/serial"
+	"github.com/Bucknalla/go-gps-simulator/gps"
 )
 
 // Version information - populated at build time via ldflags
@@ -18,31 +19,8 @@ var (
 	BuildDate = "unknown" // Will be set to build timestamp
 )
 
-type Config struct {
-	Latitude       float64
-	Longitude      float64
-	Radius         float64 // in meters
-	Altitude       float64 // starting altitude in meters
-	Jitter         float64 // GPS jitter factor (0.0-1.0)
-	AltitudeJitter float64 // altitude jitter factor (0.0-1.0)
-	Speed          float64 // static speed in knots
-	Course         float64 // static course in degrees (0-359)
-	Satellites     int
-	TimeToLock     time.Duration
-	OutputRate     time.Duration
-	SerialPort     string        // Serial port device (e.g., /dev/ttyUSB0, COM1)
-	BaudRate       int           // Serial baud rate
-	Quiet          bool          // Suppress informational messages
-	GPXEnabled     bool          // Enable GPX file generation with timestamp filename
-	GPXFile        string        // Generated GPX filename (internal use)
-	Duration       time.Duration // How long to run the simulation (0 = run indefinitely)
-	ReplayFile     string        // GPX file to replay (empty = normal simulation mode)
-	ReplaySpeed    float64       // Replay speed multiplier (1.0 = real-time, 2.0 = 2x speed, etc.)
-	ReplayLoop     bool          // Whether to loop the replay (false = stop after one pass, true = loop continuously)
-}
-
 func main() {
-	var config Config
+	var config gps.Config
 	var showVersion bool
 
 	// Define command line flags
@@ -181,7 +159,7 @@ func main() {
 	}
 
 	// Start GPS simulation
-	simulator, err := NewGPSSimulator(config, nmeaWriter)
+	simulator, err := gps.NewGPSSimulator(config, nmeaWriter)
 	if err != nil {
 		log.Fatalf("Failed to create GPS simulator: %v", err)
 	}

--- a/cmd/gps-simulator/main_test.go
+++ b/cmd/gps-simulator/main_test.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Bucknalla/go-gps-simulator/gps"
 )
 
 // Test Config struct
 func TestConfig(t *testing.T) {
-	config := Config{
+	config := gps.Config{
 		Latitude:       37.7749,
 		Longitude:      -122.4194,
 		Radius:         100.0,
@@ -102,7 +104,7 @@ func TestVersionVariables(t *testing.T) {
 // but we can test the components that main() uses
 func TestMainComponents(t *testing.T) {
 	// Test that we can create a basic config (simulating what main does)
-	config := Config{
+	config := gps.Config{
 		Latitude:   37.7749,
 		Longitude:  -122.4194,
 		Radius:     100.0,
@@ -172,7 +174,7 @@ func TestConfigValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := Config{
+			config := gps.Config{
 				Satellites:     tc.satellites,
 				Radius:         tc.radius,
 				Jitter:         tc.jitter,
@@ -217,7 +219,7 @@ func TestConfigValidation(t *testing.T) {
 // Test that we can simulate the main function workflow without actually running it
 func TestMainWorkflow(t *testing.T) {
 	// Simulate the main function workflow
-	config := Config{
+	config := gps.Config{
 		Latitude:   37.7749,
 		Longitude:  -122.4194,
 		Radius:     100.0,
@@ -231,7 +233,7 @@ func TestMainWorkflow(t *testing.T) {
 
 	// Test that we can create a simulator (what main does)
 	nmeaWriter := os.Stdout // This is what main uses when no serial port is specified
-	simulator, err := NewGPSSimulator(config, nmeaWriter)
+	simulator, err := gps.NewGPSSimulator(config, nmeaWriter)
 	if err != nil {
 		t.Fatalf("Failed to create GPS simulator: %v", err)
 	}
@@ -242,13 +244,13 @@ func TestMainWorkflow(t *testing.T) {
 
 	// Test that the simulator is properly configured
 	if simulator != nil {
-		if simulator.config.Latitude != config.Latitude {
+		if simulator.Config.Latitude != config.Latitude {
 			t.Error("Simulator should be configured with the same latitude as config")
 		}
-		if simulator.config.Longitude != config.Longitude {
+		if simulator.Config.Longitude != config.Longitude {
 			t.Error("Simulator should be configured with the same longitude as config")
 		}
-		if len(simulator.satellites) != config.Satellites {
+		if len(simulator.Satellites) != config.Satellites {
 			t.Error("Simulator should have the correct number of satellites")
 		}
 	}
@@ -266,7 +268,7 @@ func TestQuietFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := Config{
+			config := gps.Config{
 				Latitude:   37.7749,
 				Longitude:  -122.4194,
 				Radius:     100.0,
@@ -284,7 +286,7 @@ func TestQuietFlag(t *testing.T) {
 			}
 
 			// Test that we can create a simulator with quiet mode
-			simulator, err := NewGPSSimulator(config, os.Stdout)
+			simulator, err := gps.NewGPSSimulator(config, os.Stdout)
 			if err != nil {
 				t.Fatalf("Failed to create GPS simulator: %v", err)
 			}
@@ -293,9 +295,9 @@ func TestQuietFlag(t *testing.T) {
 			}
 
 			// Verify the quiet setting is preserved in the simulator's config
-			if simulator != nil && simulator.config.Quiet != tt.quiet {
+			if simulator != nil && simulator.Config.Quiet != tt.quiet {
 				t.Errorf("Expected simulator config.Quiet to be %t, got %t",
-					tt.quiet, simulator.config.Quiet)
+					tt.quiet, simulator.Config.Quiet)
 			}
 		})
 	}
@@ -304,7 +306,7 @@ func TestQuietFlag(t *testing.T) {
 // Test quiet flag behavior in different scenarios
 func TestQuietFlagBehavior(t *testing.T) {
 	// Test default quiet value (should be false)
-	var config Config
+	var config gps.Config
 	if config.Quiet != false {
 		t.Errorf("Default Quiet value should be false, got %t", config.Quiet)
 	}
@@ -339,7 +341,7 @@ func TestMainFunctionComponents(t *testing.T) {
 
 	// Test config creation and validation (simulates flag parsing)
 	tempDir := t.TempDir()
-	config := Config{
+	config := gps.Config{
 		Latitude:       37.7749,
 		Longitude:      -122.4194,
 		Radius:         100.0,
@@ -371,7 +373,7 @@ func TestMainFunctionComponents(t *testing.T) {
 
 	// Test simulator creation (simulates main's simulator creation)
 	nmeaWriter := os.Stdout
-	simulator, err := NewGPSSimulator(config, nmeaWriter)
+	simulator, err := gps.NewGPSSimulator(config, nmeaWriter)
 	if err != nil {
 		t.Fatalf("Failed to create GPS simulator: %v", err)
 	}
@@ -381,10 +383,10 @@ func TestMainFunctionComponents(t *testing.T) {
 	}
 
 	// Test that simulator has correct config
-	if simulator.config.Latitude != config.Latitude {
+	if simulator.Config.Latitude != config.Latitude {
 		t.Error("Simulator should have correct latitude")
 	}
-	if simulator.config.GPXEnabled != config.GPXEnabled {
+	if simulator.Config.GPXEnabled != config.GPXEnabled {
 		t.Error("Simulator should have correct GPX settings")
 	}
 
@@ -394,9 +396,9 @@ func TestMainFunctionComponents(t *testing.T) {
 }
 
 func TestConfigFieldAccess(t *testing.T) {
-	// Test that all Config fields are properly accessible and assignable
+	// Test that all gps.Config fields are properly accessible and assignable
 	// This indirectly tests the struct definition used by main()
-	config := Config{}
+	config := gps.Config{}
 
 	// Test all numeric fields
 	config.Latitude = 1.0
@@ -442,7 +444,7 @@ func TestConfigFieldAccess(t *testing.T) {
 // Test that quiet mode affects the correct behavior in simulator
 func TestQuietModeIntegration(t *testing.T) {
 	// Test with quiet mode enabled
-	quietConfig := Config{
+	quietConfig := gps.Config{
 		Latitude:   37.7749,
 		Longitude:  -122.4194,
 		Radius:     100.0,
@@ -454,16 +456,16 @@ func TestQuietModeIntegration(t *testing.T) {
 		Quiet:      true,
 	}
 
-	quietSim, err := NewGPSSimulator(quietConfig, os.Stdout)
+	quietSim, err := gps.NewGPSSimulator(quietConfig, os.Stdout)
 	if err != nil {
 		t.Fatalf("Failed to create GPS simulator: %v", err)
 	}
-	if !quietSim.config.Quiet {
+	if !quietSim.Config.Quiet {
 		t.Error("Simulator should preserve quiet mode setting")
 	}
 
 	// Test with quiet mode disabled
-	verboseConfig := Config{
+	verboseConfig := gps.Config{
 		Latitude:   37.7749,
 		Longitude:  -122.4194,
 		Radius:     100.0,
@@ -475,11 +477,11 @@ func TestQuietModeIntegration(t *testing.T) {
 		Quiet:      false,
 	}
 
-	verboseSim, err := NewGPSSimulator(verboseConfig, os.Stdout)
+	verboseSim, err := gps.NewGPSSimulator(verboseConfig, os.Stdout)
 	if err != nil {
 		t.Fatalf("Failed to create GPS simulator: %v", err)
 	}
-	if verboseSim.config.Quiet {
+	if verboseSim.Config.Quiet {
 		t.Error("Simulator should preserve non-quiet mode setting")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-gps-simulator
+module github.com/Bucknalla/go-gps-simulator
 
 go 1.23
 

--- a/gps/gpx.go
+++ b/gps/gpx.go
@@ -1,4 +1,4 @@
-package main
+package gps
 
 import (
 	"encoding/xml"

--- a/gps/gpx_test.go
+++ b/gps/gpx_test.go
@@ -1,4 +1,4 @@
-package main
+package gps
 
 import (
 	"encoding/xml"

--- a/gps/nmea.go
+++ b/gps/nmea.go
@@ -1,4 +1,4 @@
-package main
+package gps
 
 import (
 	"fmt"
@@ -43,7 +43,7 @@ func (s *GPSSimulator) generateGGA(timestamp time.Time) string {
 
 	// Quality indicator: 1 = GPS fix
 	quality := "1"
-	numSats := fmt.Sprintf("%02d", len(s.satellites))
+	numSats := fmt.Sprintf("%02d", len(s.Satellites))
 	hdop := "1.2"                                 // Horizontal dilution of precision
 	altitude := fmt.Sprintf("%.1f", s.currentAlt) // Current altitude above mean sea level
 	altUnit := "M"
@@ -125,7 +125,7 @@ func (s *GPSSimulator) generateGSA() string {
 
 	// List up to 12 satellite IDs being used for fix
 	var satIDs []string
-	for i, sat := range s.satellites {
+	for i, sat := range s.Satellites {
 		if i < 12 {
 			satIDs = append(satIDs, fmt.Sprintf("%02d", sat.ID))
 		}
@@ -152,7 +152,7 @@ func (s *GPSSimulator) generateGSA() string {
 func (s *GPSSimulator) generateGSV() []string {
 	var sentences []string
 
-	totalSats := len(s.satellites)
+	totalSats := len(s.Satellites)
 	totalSentences := (totalSats + 3) / 4 // Round up to nearest 4
 
 	for sentenceNum := 1; sentenceNum <= totalSentences; sentenceNum++ {
@@ -167,7 +167,7 @@ func (s *GPSSimulator) generateGSV() []string {
 
 		// Add satellite data (up to 4 satellites per sentence)
 		for i := startIdx; i < endIdx; i++ {
-			sat := s.satellites[i]
+			sat := s.Satellites[i]
 			sentence += fmt.Sprintf(",%02d,%02d,%03d,%02d",
 				sat.ID, sat.Elevation, sat.Azimuth, sat.SNR)
 		}

--- a/gps/nmea_test.go
+++ b/gps/nmea_test.go
@@ -1,4 +1,4 @@
-package main
+package gps
 
 import (
 	"bytes"
@@ -88,11 +88,11 @@ func createTestSimulator() *GPSSimulator {
 	}
 
 	sim := &GPSSimulator{
-		config:     config,
+		Config:     config,
 		currentLat: config.Latitude,
 		currentLon: config.Longitude,
 		isLocked:   true,
-		satellites: []Satellite{
+		Satellites: []Satellite{
 			{ID: 1, Elevation: 45, Azimuth: 90, SNR: 35},
 			{ID: 2, Elevation: 60, Azimuth: 180, SNR: 40},
 			{ID: 3, Elevation: 30, Azimuth: 270, SNR: 25},
@@ -250,7 +250,7 @@ func TestGenerateRMCWithSpeedAndCourse(t *testing.T) {
 
 	now := time.Now()
 	sim := &GPSSimulator{
-		config:         config,
+		Config:         config,
 		currentLat:     config.Latitude,
 		currentLon:     config.Longitude,
 		currentSpeed:   config.Speed,
@@ -334,7 +334,7 @@ func TestUpdateSpeedAndCourse(t *testing.T) {
 
 			now := time.Now()
 			sim := &GPSSimulator{
-				config:         config,
+				Config:         config,
 				currentSpeed:   config.Speed,
 				currentCourse:  config.Course,
 				lastUpdateTime: now,
@@ -422,8 +422,8 @@ func TestGenerateGSA(t *testing.T) {
 			satCount++
 		}
 	}
-	if satCount != len(sim.satellites) {
-		t.Errorf("generateGSA should contain %d satellite IDs, got %d", len(sim.satellites), satCount)
+	if satCount != len(sim.Satellites) {
+		t.Errorf("generateGSA should contain %d satellite IDs, got %d", len(sim.Satellites), satCount)
 	}
 }
 
@@ -471,9 +471,9 @@ func TestGenerateGSV(t *testing.T) {
 func TestGenerateGSVMultipleSentences(t *testing.T) {
 	// Create simulator with many satellites to test multiple GSV sentences
 	sim := createTestSimulator()
-	sim.satellites = make([]Satellite, 12) // Maximum satellites
+	sim.Satellites = make([]Satellite, 12) // Maximum satellites
 	for i := 0; i < 12; i++ {
-		sim.satellites[i] = Satellite{
+		sim.Satellites[i] = Satellite{
 			ID:        i + 1,
 			Elevation: 45,
 			Azimuth:   i * 30,
@@ -672,7 +672,7 @@ func TestVTGSpeedConversion(t *testing.T) {
 
 	now := time.Now()
 	sim := &GPSSimulator{
-		config:         config,
+		Config:         config,
 		currentSpeed:   config.Speed,
 		currentCourse:  config.Course,
 		isLocked:       true,

--- a/gps/simulator_test.go
+++ b/gps/simulator_test.go
@@ -1,4 +1,4 @@
-package main
+package gps
 
 import (
 	"bytes"
@@ -43,17 +43,17 @@ func TestNewGPSSimulator(t *testing.T) {
 	}
 
 	// Test config assignment
-	if sim.config.Latitude != config.Latitude {
-		t.Errorf("Expected latitude %f, got %f", config.Latitude, sim.config.Latitude)
+	if sim.Config.Latitude != config.Latitude {
+		t.Errorf("Expected latitude %f, got %f", config.Latitude, sim.Config.Latitude)
 	}
-	if sim.config.Longitude != config.Longitude {
-		t.Errorf("Expected longitude %f, got %f", config.Longitude, sim.config.Longitude)
+	if sim.Config.Longitude != config.Longitude {
+		t.Errorf("Expected longitude %f, got %f", config.Longitude, sim.Config.Longitude)
 	}
-	if sim.config.Radius != config.Radius {
-		t.Errorf("Expected radius %f, got %f", config.Radius, sim.config.Radius)
+	if sim.Config.Radius != config.Radius {
+		t.Errorf("Expected radius %f, got %f", config.Radius, sim.Config.Radius)
 	}
-	if sim.config.Satellites != config.Satellites {
-		t.Errorf("Expected satellites %d, got %d", config.Satellites, sim.config.Satellites)
+	if sim.Config.Satellites != config.Satellites {
+		t.Errorf("Expected satellites %d, got %d", config.Satellites, sim.Config.Satellites)
 	}
 
 	// Test initial position
@@ -73,8 +73,8 @@ func TestNewGPSSimulator(t *testing.T) {
 	}
 
 	// Test satellites initialization
-	if len(sim.satellites) != config.Satellites {
-		t.Errorf("Expected %d satellites, got %d", config.Satellites, len(sim.satellites))
+	if len(sim.Satellites) != config.Satellites {
+		t.Errorf("Expected %d satellites, got %d", config.Satellites, len(sim.Satellites))
 	}
 
 	// Test writer assignment
@@ -100,12 +100,12 @@ func TestInitializeSatellites(t *testing.T) {
 	}
 
 	// Test satellite count
-	if len(sim.satellites) != config.Satellites {
-		t.Errorf("Expected %d satellites, got %d", config.Satellites, len(sim.satellites))
+	if len(sim.Satellites) != config.Satellites {
+		t.Errorf("Expected %d satellites, got %d", config.Satellites, len(sim.Satellites))
 	}
 
 	// Test satellite properties
-	for i, sat := range sim.satellites {
+	for i, sat := range sim.Satellites {
 		// Test ID assignment
 		expectedID := i + 1
 		if sat.ID != expectedID {
@@ -640,15 +640,15 @@ func TestUpdateSatellites(t *testing.T) {
 	}
 
 	// Store initial satellite states
-	initialSats := make([]Satellite, len(sim.satellites))
-	copy(initialSats, sim.satellites)
+	initialSats := make([]Satellite, len(sim.Satellites))
+	copy(initialSats, sim.Satellites)
 
 	// Update satellites multiple times
 	for i := 0; i < 10; i++ {
 		sim.updateSatellites()
 
 		// Check that all satellites remain within valid bounds
-		for j, sat := range sim.satellites {
+		for j, sat := range sim.Satellites {
 			// Check elevation bounds
 			if sat.Elevation < 5 || sat.Elevation > 85 {
 				t.Errorf("Update %d: Satellite %d elevation %d out of bounds (5-85)",
@@ -677,7 +677,7 @@ func TestUpdateSatellites(t *testing.T) {
 
 	// Check that at least some satellites have changed
 	changed := false
-	for i, sat := range sim.satellites {
+	for i, sat := range sim.Satellites {
 		if sat.Elevation != initialSats[i].Elevation ||
 			sat.Azimuth != initialSats[i].Azimuth ||
 			sat.SNR != initialSats[i].SNR {
@@ -699,27 +699,27 @@ func TestUpdateSatellitesBoundaryConditions(t *testing.T) {
 	}
 
 	// Test elevation boundary conditions
-	sim.satellites[0].Elevation = 4  // Below minimum
-	sim.satellites[1].Elevation = 86 // Above maximum
+	sim.Satellites[0].Elevation = 4  // Below minimum
+	sim.Satellites[1].Elevation = 86 // Above maximum
 
 	// Test SNR boundary conditions
-	sim.satellites[2].SNR = 14 // Below minimum
-	sim.satellites[3].SNR = 56 // Above maximum
+	sim.Satellites[2].SNR = 14 // Below minimum
+	sim.Satellites[3].SNR = 56 // Above maximum
 
 	sim.updateSatellites()
 
 	// Check that boundaries are enforced
-	if sim.satellites[0].Elevation < 5 {
-		t.Errorf("Expected elevation to be at least 5, got %d", sim.satellites[0].Elevation)
+	if sim.Satellites[0].Elevation < 5 {
+		t.Errorf("Expected elevation to be at least 5, got %d", sim.Satellites[0].Elevation)
 	}
-	if sim.satellites[1].Elevation > 85 {
-		t.Errorf("Expected elevation to be at most 85, got %d", sim.satellites[1].Elevation)
+	if sim.Satellites[1].Elevation > 85 {
+		t.Errorf("Expected elevation to be at most 85, got %d", sim.Satellites[1].Elevation)
 	}
-	if sim.satellites[2].SNR < 15 {
-		t.Errorf("Expected SNR to be at least 15, got %d", sim.satellites[2].SNR)
+	if sim.Satellites[2].SNR < 15 {
+		t.Errorf("Expected SNR to be at least 15, got %d", sim.Satellites[2].SNR)
 	}
-	if sim.satellites[3].SNR > 55 {
-		t.Errorf("Expected SNR to be at most 55, got %d", sim.satellites[3].SNR)
+	if sim.Satellites[3].SNR > 55 {
+		t.Errorf("Expected SNR to be at most 55, got %d", sim.Satellites[3].SNR)
 	}
 }
 
@@ -815,7 +815,7 @@ func TestOutputNMEA(t *testing.T) {
 
 	// Count GSV sentences (should be based on number of satellites)
 	gsvCount := strings.Count(output, "$GPGSV,")
-	expectedGSVCount := (len(sim.satellites) + 3) / 4 // Round up to nearest 4
+	expectedGSVCount := (len(sim.Satellites) + 3) / 4 // Round up to nearest 4
 	if gsvCount != expectedGSVCount {
 		t.Errorf("Expected %d GSV sentences, got %d", expectedGSVCount, gsvCount)
 	}
@@ -988,7 +988,7 @@ func TestGenerateGSVEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create GPS simulator: %v", err)
 	}
-	sim.satellites = []Satellite{} // Empty satellites
+	sim.Satellites = []Satellite{} // Empty satellites
 
 	result := sim.generateGSV()
 	if len(result) != 0 {
@@ -996,7 +996,7 @@ func TestGenerateGSVEdgeCases(t *testing.T) {
 	}
 
 	// Test with 1 satellite (to test padding logic)
-	sim.satellites = []Satellite{
+	sim.Satellites = []Satellite{
 		{ID: 1, Elevation: 45, Azimuth: 90, SNR: 35},
 	}
 
@@ -1012,7 +1012,7 @@ func TestGenerateGSVEdgeCases(t *testing.T) {
 	}
 
 	// Test with 3 satellites (to test partial padding)
-	sim.satellites = []Satellite{
+	sim.Satellites = []Satellite{
 		{ID: 1, Elevation: 45, Azimuth: 90, SNR: 35},
 		{ID: 2, Elevation: 60, Azimuth: 180, SNR: 40},
 		{ID: 3, Elevation: 30, Azimuth: 270, SNR: 25},
@@ -1030,7 +1030,7 @@ func TestGenerateGSVEdgeCases(t *testing.T) {
 	}
 
 	// Test with exactly 4 satellites (no padding needed)
-	sim.satellites = []Satellite{
+	sim.Satellites = []Satellite{
 		{ID: 1, Elevation: 45, Azimuth: 90, SNR: 35},
 		{ID: 2, Elevation: 60, Azimuth: 180, SNR: 40},
 		{ID: 3, Elevation: 30, Azimuth: 270, SNR: 25},
@@ -1115,19 +1115,19 @@ func TestUpdateSatellitesEdgeCases(t *testing.T) {
 		snrChanges := 0
 
 		for i := 0; i < 10; i++ {
-			prevElev := sim.satellites[0].Elevation
-			prevAzim := sim.satellites[0].Azimuth
-			prevSNR := sim.satellites[0].SNR
+			prevElev := sim.Satellites[0].Elevation
+			prevAzim := sim.Satellites[0].Azimuth
+			prevSNR := sim.Satellites[0].SNR
 
 			sim.updateSatellites()
 
-			if sim.satellites[0].Elevation != prevElev {
+			if sim.Satellites[0].Elevation != prevElev {
 				elevationChanges++
 			}
-			if sim.satellites[0].Azimuth != prevAzim {
+			if sim.Satellites[0].Azimuth != prevAzim {
 				azimuthChanges++
 			}
-			if sim.satellites[0].SNR != prevSNR {
+			if sim.Satellites[0].SNR != prevSNR {
 				snrChanges++
 			}
 		}
@@ -1147,16 +1147,16 @@ func TestUpdateSatellitesEdgeCases(t *testing.T) {
 		}
 
 		// Set satellites to boundary values
-		sim.satellites[0].Elevation = 4  // Below minimum
-		sim.satellites[1].Elevation = 86 // Above maximum
-		sim.satellites[2].SNR = 14       // Below minimum
-		sim.satellites[3].SNR = 56       // Above maximum
+		sim.Satellites[0].Elevation = 4  // Below minimum
+		sim.Satellites[1].Elevation = 86 // Above maximum
+		sim.Satellites[2].SNR = 14       // Below minimum
+		sim.Satellites[3].SNR = 56       // Above maximum
 
 		// Update multiple times to ensure boundaries are maintained
 		for i := 0; i < 20; i++ {
 			sim.updateSatellites()
 
-			for j, sat := range sim.satellites {
+			for j, sat := range sim.Satellites {
 				if sat.Elevation < 5 || sat.Elevation > 85 {
 					t.Errorf("Satellite %d elevation %d out of bounds [5, 85]", j, sat.Elevation)
 				}
@@ -1789,7 +1789,7 @@ func TestDeterministicBoundaryConditions(t *testing.T) {
 		}
 
 		// Force a scenario where speed goes negative
-		sim.config.Speed = 1.0
+		sim.Config.Speed = 1.0
 		sim.currentSpeed = 1.0
 
 		// Manually set a large negative delta to force the boundary condition
@@ -1840,19 +1840,19 @@ func TestDeterministicBoundaryConditions(t *testing.T) {
 		}
 
 		// Force satellites to boundary conditions
-		for i := range sim.satellites {
+		for i := range sim.Satellites {
 			// Test low elevation boundary
-			sim.satellites[i].Elevation = 3 // Below minimum of 5
+			sim.Satellites[i].Elevation = 3 // Below minimum of 5
 			sim.updateSatellites()
-			if sim.satellites[i].Elevation < 5 {
-				t.Errorf("Satellite %d elevation should be at least 5, got %d", i, sim.satellites[i].Elevation)
+			if sim.Satellites[i].Elevation < 5 {
+				t.Errorf("Satellite %d elevation should be at least 5, got %d", i, sim.Satellites[i].Elevation)
 			}
 
 			// Test high elevation boundary
-			sim.satellites[i].Elevation = 87 // Above maximum of 85
+			sim.Satellites[i].Elevation = 87 // Above maximum of 85
 			sim.updateSatellites()
-			if sim.satellites[i].Elevation > 85 {
-				t.Errorf("Satellite %d elevation should be at most 85, got %d", i, sim.satellites[i].Elevation)
+			if sim.Satellites[i].Elevation > 85 {
+				t.Errorf("Satellite %d elevation should be at most 85, got %d", i, sim.Satellites[i].Elevation)
 			}
 		}
 	})
@@ -1866,19 +1866,19 @@ func TestDeterministicBoundaryConditions(t *testing.T) {
 		}
 
 		// Force satellites to SNR boundary conditions
-		for i := range sim.satellites {
+		for i := range sim.Satellites {
 			// Test low SNR boundary
-			sim.satellites[i].SNR = 10 // Below minimum of 15
+			sim.Satellites[i].SNR = 10 // Below minimum of 15
 			sim.updateSatellites()
-			if sim.satellites[i].SNR < 15 {
-				t.Errorf("Satellite %d SNR should be at least 15, got %d", i, sim.satellites[i].SNR)
+			if sim.Satellites[i].SNR < 15 {
+				t.Errorf("Satellite %d SNR should be at least 15, got %d", i, sim.Satellites[i].SNR)
 			}
 
 			// Test high SNR boundary
-			sim.satellites[i].SNR = 60 // Above maximum of 55
+			sim.Satellites[i].SNR = 60 // Above maximum of 55
 			sim.updateSatellites()
-			if sim.satellites[i].SNR > 55 {
-				t.Errorf("Satellite %d SNR should be at most 55, got %d", i, sim.satellites[i].SNR)
+			if sim.Satellites[i].SNR > 55 {
+				t.Errorf("Satellite %d SNR should be at most 55, got %d", i, sim.Satellites[i].SNR)
 			}
 		}
 	})
@@ -1901,7 +1901,7 @@ func TestDeterministicBoundaryConditions(t *testing.T) {
 		}
 
 		// Test minimum relative to starting altitude
-		sim.config.Altitude = 200.0 // High starting altitude
+		sim.Config.Altitude = 200.0 // High starting altitude
 		sim.currentAlt = 80.0       // Below (200 - 100) = 100m minimum
 		sim.updateAltitude()
 		if sim.currentAlt < 100.0 {
@@ -1916,7 +1916,7 @@ func TestDeterministicBoundaryConditions(t *testing.T) {
 		}
 
 		// Test the sea level boundary condition specifically
-		sim.config.Altitude = 10.0 // Low starting altitude
+		sim.Config.Altitude = 10.0 // Low starting altitude
 		sim.currentAlt = -60.0     // This should trigger the -50.0 sea level minimum
 		sim.updateAltitude()
 		if sim.currentAlt < -50.0 {
@@ -2562,16 +2562,16 @@ func TestReplaySpeedZeroDefensiveCheck(t *testing.T) {
 					t.Errorf("Expected warning for invalid replay speed %.3f, got: %s", tc.replaySpeed, output)
 				}
 				// Speed should have been corrected to 1.0
-				if sim.config.ReplaySpeed != 1.0 {
-					t.Errorf("Expected replay speed to be corrected to 1.0, got %.3f", sim.config.ReplaySpeed)
+				if sim.Config.ReplaySpeed != 1.0 {
+					t.Errorf("Expected replay speed to be corrected to 1.0, got %.3f", sim.Config.ReplaySpeed)
 				}
 			} else {
 				if strings.Contains(output, "Warning: Invalid replay speed") {
 					t.Errorf("Unexpected warning for valid replay speed %.3f: %s", tc.replaySpeed, output)
 				}
 				// Speed should remain unchanged
-				if sim.config.ReplaySpeed != tc.replaySpeed {
-					t.Errorf("Expected replay speed to remain %.3f, got %.3f", tc.replaySpeed, sim.config.ReplaySpeed)
+				if sim.Config.ReplaySpeed != tc.replaySpeed {
+					t.Errorf("Expected replay speed to remain %.3f, got %.3f", tc.replaySpeed, sim.Config.ReplaySpeed)
 				}
 			}
 


### PR DESCRIPTION
- Restructure code to make GPS simulator importable as a library
- Move core functionality (simulator.go, nmea.go, gpx.go) to gps/ package
- Move main program to cmd/gps-simulator/
- Update module path to github.com/Bucknalla/go-gps-simulator
- Export Config, GPSSimulator, and related types for external use
- Maintain backward compatibility for command-line usage

This enables the GPS simulator to be used both as a standalone CLI tool and as an importable Go library for other projects.